### PR TITLE
Including transformation matrix for touchscreen input rotation.

### DIFF
--- a/src/input_rotation.h
+++ b/src/input_rotation.h
@@ -1,0 +1,21 @@
+//
+// Created by raffaele on 18/12/19.
+//
+
+#ifndef E_GADGET_CONVERTIBLE_INPUT_ROTATION_H
+#define E_GADGET_CONVERTIBLE_INPUT_ROTATION_H
+
+typedef struct _TransformationMatrix {
+   float values[9];
+} TransformationMatrix;
+
+
+static const float MATRIX_ROTATION_IDENTITY[6] = {1, 0, 0, 0, 1, 0 };
+static const float MATRIX_ROTATION_90[6] = {0, 1, 0, -1, 0, 1 };
+static const float MATRIX_ROTATION_180[6] = {-1, 0, 1, 0, -1, 1 };
+static const float MATRIX_ROTATION_270[6] = {0, -1, 1, 1, 0, 0 };
+
+static const char *core_pointer_name = "Virtual core pointer";
+// "Coordinate Transformation Matrix"
+static const char *CTM_name = "Coordinate Transformation Matrix";
+#endif //E_GADGET_CONVERTIBLE_INPUT_ROTATION_H


### PR DESCRIPTION
In the dbus module, try to locate the touchscreen device and rotate it
accordingly. It's ugly to do it in the dbus_acceleration.c file but for
the time being it will have to do. I will refactor later. Close #5